### PR TITLE
fix(mcp): drop .value on string episode_type in display code

### DIFF
--- a/src/remind/mcp_server.py
+++ b/src/remind/mcp_server.py
@@ -140,7 +140,7 @@ async def tool_remember(
     lines = [f"Remembered as episode {episode_id}"]
     
     if ep_type:
-        lines.append(f"  Type: {ep_type.value}")
+        lines.append(f"  Type: {ep_type}")
     if entity_list:
         lines.append(f"  Entities: {', '.join(entity_list)}")
     if topic:
@@ -593,7 +593,7 @@ async def tool_update_episode(
             preview = content[:50] + "..." if len(content) > 50 else content
             lines.append(f"  Content: {preview}")
         if ep_type:
-            lines.append(f"  Type: {ep_type.value}")
+            lines.append(f"  Type: {ep_type}")
         if entity_list:
             lines.append(f"  Entities: {', '.join(entity_list)}")
         if plan_id:


### PR DESCRIPTION
## Bug

The `remember` and `update_episode` MCP tools crash when `episode_type` is passed as a parameter.

**Error:** `'str' object has no attribute 'value'`

**Reproduction:** Call `remember` via MCP with `episode_type="fact"` (or any valid type).

## Root Cause

MCP tool parameters always arrive as plain strings (e.g. `"fact"`), not `EpisodeType` enums. The display code in `tool_remember()` and `tool_update_episode()` calls `ep_type.value`, which fails on strings.

## Fix

Remove `.value` from the two display lines. The string is already the enum's value (`"fact"` == `EpisodeType.FACT.value`), so output is identical.

**Before:** `lines.append(f"  Type: {ep_type.value}")`
**After:** `lines.append(f"  Type: {ep_type}")`

## Affected Lines

- `remind/mcp_server.py` — `tool_remember()` display code
- `remind/mcp_server.py` — `tool_update_episode()` display code